### PR TITLE
Switch to official C# AOT project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,15 +83,15 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.0.100-preview.1.23115.2'
+        dotnet-version: '8.0.100-preview.4.23260.5'
     - name: Build
       shell: cmd
       run: |
         cd csharp
         dotnet --info
-        dotnet publish -p:PublishAot=true
+        dotnet publish
         (
-        echo LANGUAGE=C-sharp
+        echo LANGUAGE=C#
         echo COMPILER=8.0.100-preview.1.23115.2
         )>bin\Release\net8.0\win-x64\publish\info.txt
     - name: Upload
@@ -139,7 +139,7 @@ jobs:
         dotnet --info
         dotnet publish -p:PublishAot=true
         (
-        echo LANGUAGE=F-sharp
+        echo LANGUAGE=F#
         echo COMPILER=8.0.100-preview.1.23115.2
         )>bin\Release\net8.0\win-x64\publish\info.txt
     - name: Upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.0.100-preview.4.23260.5'
+        dotnet-version: '8.0.100-preview.1.23115.2'
     - name: Build
       shell: cmd
       run: |
@@ -140,7 +140,7 @@ jobs:
         dotnet publish -p:PublishAot=true
         (
         echo LANGUAGE=F#
-        echo COMPILER=8.0.100-preview.4.23260.5
+        echo COMPILER=8.0.100-preview.1.23115.2
         )>bin\Release\net8.0\win-x64\publish\info.txt
     - name: Upload
       uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
         dotnet publish
         (
         echo LANGUAGE=C#
-        echo COMPILER=8.0.100-preview.1.23115.2
+        echo COMPILER=8.0.100-preview.4.23260.5
         )>bin\Release\net8.0\win-x64\publish\info.txt
     - name: Upload
       uses: actions/upload-artifact@v3
@@ -131,7 +131,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '8.0.100-preview.1.23115.2'
+        dotnet-version: '8.0.100-preview.4.23260.5'
     - name: Build
       shell: cmd
       run: |
@@ -140,7 +140,7 @@ jobs:
         dotnet publish -p:PublishAot=true
         (
         echo LANGUAGE=F#
-        echo COMPILER=8.0.100-preview.1.23115.2
+        echo COMPILER=8.0.100-preview.4.23260.5
         )>bin\Release\net8.0\win-x64\publish\info.txt
     - name: Upload
       uses: actions/upload-artifact@v3
@@ -182,7 +182,7 @@ jobs:
     - uses: graalvm/setup-graalvm@v1
       with:
         version: 'latest'
-        java-version: '19'
+        java-version: '17'
         components: 'native-image'
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build

--- a/csharp/hello.csproj
+++ b/csharp/hello.csproj
@@ -4,6 +4,9 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Match csproj with `dotnet new console --aot`. Stop passing `PublishAot` on the command line.